### PR TITLE
Reword many fields, add explanations, move fields into different sections.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -266,7 +266,7 @@
                 </li>
 
                 <li>
-                    <label>Conflicts with (mod will break or will break these mods)<br /><textarea id="conflicts" cols="40"></textarea></label>
+                    <label>Conflicts with (mod will be break or be broken by these mods)<br /><textarea id="conflicts" cols="40"></textarea></label>
                     <button type="button" id="add_conflicts_button">Add</button>
                     <div id="add_conflicts" title="Add conflicted">
                         <div class="ui-widget">

--- a/static/index.html
+++ b/static/index.html
@@ -108,35 +108,35 @@
         </div>
     </div>
     <p>
-        Fields filled by the NetKAN indexer look like <input type="text" class="filled-by-netkan" disabled="disabled" /> - you can override auto-detection by setting a value yourself. <em>If unsure - don't override.</em>
+        Fields filled by the NetKAN indexer look like <input type="text" class="filled-by-netkan" disabled="disabled" /> - you can override auto-detection by setting a value yourself. <strong>If unsure - don't override.</strong>
     </p>
     <div id="accordion">
         <h3>Mandatory</h3>
         <div>
             <ol id="mandatory_fields">
                 <li>
-                    <label>Identifier<br /><input type="text" id="identifier" placeholder="Machine-friendly name for the mod" size="40" pattern="^[A-Za-z][A-Za-z0-9-]*$" /></label> <em id="identifier_info"></em>
+                    <label>Identifier - Machine-friendly name for the mod (only numbers, letters, and dashes, no spaces)<br /><input type="text" id="identifier" placeholder="AwesomeMod" size="40" pattern="^[A-Za-z][A-Za-z0-9-]*$" /></label> <strong id="identifier_info"></strong>
                 </li>
                 <li>
-                    <label>Name<br /><input type="text" id="name" placeholder="User-friendly name for the mod" size="40" /></label> <em id="name_info"></em>
+                    <label>Name - User-friendly name for the mod<br /><input type="text" id="name" placeholder="Awesome Mod" size="40" /></label> <strong id="name_info"></strong>
                 </li>
                 <li>
                     <label><input type="checkbox" id="add_vref" value="1" onchange="switch_add_vref()" /> Installs <code>.version</code> file</label>
                 </li>
                 <li>
-                    <label>Version<br /><input type="text" id="version" size="40" /></label>
+                    <label>Mod Version<br /><input type="text" id="version" size="40" /></label>
                 </li>
                 <li>
-                    <label>Abstract<br /><textarea id="abstract" placeholder="A short description of what the mod does" size="40"></textarea></label>
+                    <label>Abstract - A short description of what the mod does<br /><textarea id="abstract" placeholder="Awesome mod makes everything better!" cols="40" ></textarea></label>
                 </li>
                 <li>
-                    <label>Download<br /><input type="url" id="download" size="40" /></label>
+                    <label>Download URI<br /><input type="url" id="download" size="40" /></label>
                 </li>
                 <li>
-                    <label>Authors (one per line)<br /><textarea id="author" cols="40"></textarea></label>
+                    <label>Mod Authors (one per line)<br /><textarea id="author" cols="40"></textarea></label>
                 </li>
                 <li>
-                    <label>Licenses<br /><textarea id="license" cols="40"></textarea></label>
+                    <label>License(s)<br /><textarea id="license" cols="40"></textarea></label>
                     <button type="button" id="add_license_button">Add</button> Users can choose to which of these to adhere
                     <div id="add_license" title="Add license">
                         <a href="https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#license" target="_blank">About valid licenses</a>
@@ -145,55 +145,52 @@
                         </div>
                     </div>
                 </li>
-
-            </ol>
-        </div>
-        <h3>Extra Info (suggested)</h3>
-        <div id="extra_fields">
-            <ol>
                 <li>
                     <label>KSP-Version<br /><input type="text" id="ksp_version" size="40" /></label> examples: <code>==1.0</code> or <code>&lt;=1.1&gt;=1.0.3</code>
+                    <br />
+                    <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
-                <li>
-                    <label><input type="checkbox" id="add_ksp_version_strict" value="1" size="40" /> Install only on exact KSP-Version match</label>
-                </li>
-            </ol>
 
+            </ol>
         </div>
-        <h3>Ressources (suggested)</h3>
+        <h3>Resources (Suggested)</h3>
         <div id="resources_fields">
             <ol>
                 <li>
-                    <label>Repository<br /><input type="url" id="resources_repository" size="40" /></label> The repository where the module source can be found
+                    <label>Homepage<br /><input type="url" id="resources_homepage" size="40" /></label> URI to the preferred landing page for the mod
                 </li>
                 <li>
-                    <label>Homepage<br /><input type="url" id="resources_homepage" size="40" /></label> The preferred landing page for the mod
-                </li>
-                <li>
-                    <label>Bugtracker<br /><input type="url" id="resources_bugtracker" size="40" /></label> The mod's bugtracker if it exists
-                </li>
+                    <label>Repository<br /><input type="url" id="resources_repository" size="40" /></label> URI to the repository where the mod's source can be found
+                </li>  
                 <li>
                     <label>CI<br /><input type="url" id="resources_ci" size="40" /></label> Continuous Integration (e.g. Jenkins) Server where the module is being built
                 </li>
                 <li>
-                    <label>SpaceDock<br /><input type="url" id="resources_spacedock" size="40" /></label> The mod on SpaceDock
+                    <label>SpaceDock<br /><input type="url" id="resources_spacedock" size="40" /></label> URI to the mod's SpaceDock page
                 </li>
                 <li>
-                    <label>Manual<br /><input type="url" id="resources_manual" size="40" /></label> The mod's bugtracker if it exists
+                    <label>Manual<br /><input type="url" id="resources_manual" size="40" /></label> URI to the mod's user manual if it exists
                 </li>
                 <li>
-                    <label>License<br /><input type="url" id="resources_license" size="40" /></label> The mod's license
+                    <label>License<br /><input type="url" id="resources_license" size="40" /></label> URI to the mod's license
                 </li>
                 <li>
-                    <label>Screenshot<br /><input type="url" id="resources_x_screenshot" size="40" /></label>
+                    <label>Bugtracker<br /><input type="url" id="resources_bugtracker" size="40" /></label> URI to the mod's bugtracker if it exists (Preferred page to post problems/questions)
+                </li>
+                <li>
+                    <label>Screenshot<br /><input type="url" id="resources_x_screenshot" size="40" /></label> A direct URL to a screenshot of the mod
                 </li>
             </ol>
         </div>
-        <h3>Special Install</h3>
+        <h3>Installation</h3>
         <div id="install_fields">
+            <p>
+                If this mod requires other mods to be installed alongside it, use Relationships.
+                <strong>Do not use install instructions to install multiple mods.</strong>
+            </p>
             <ol>
                 <li>
-                    <label>Install Root<br /><input type="text" id="file" size="40" /></label>
+                    <label>Install from<br /><input type="text" id="file" size="40" /></label>
                 </li>
                 <li>
                     <label>
@@ -213,14 +210,14 @@
                 </li>
             </ol>
         </div>
-        <h3>References</h3>
+        <h3>Relationships</h3>
         <div id="references_fields">
             <p>
                 You can add version restrictions. For example <code>SomeModID</code> can be restricted like <code>SomeModID ==1.0</code> or <code>SomeModID &lt;=1.1 &gt;=1.0.3</code>
             </p>
             <ol>
                 <li>
-                    <label>Depends on<br /><textarea id="depends" cols="40"></textarea></label>
+                    <label>Depends on (mod will not run without it)<br /><textarea id="depends" cols="40"></textarea></label>
                     <button type="button" id="add_depends_button">Add</button>
                     <div id="add_depends" title="Add requirement">
                         <div class="ui-widget">
@@ -232,7 +229,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Recommends<br /><textarea id="recommends" cols="40"></textarea></label>
+                    <label>Recommends (mod is greatly complimented by these mods)<br /><textarea id="recommends" cols="40"></textarea></label>
                     <button type="button" id="add_recommends_button">Add</button>
                     <div id="add_recommends" title="Add recommendation">
                         <div class="ui-widget">
@@ -244,7 +241,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Suggests<br /><textarea id="suggests" cols="40"></textarea></label>
+                    <label>Suggests (mod is complimented by these mods)<br /><textarea id="suggests" cols="40"></textarea></label>
                     <button type="button" id="add_suggests_button">Add</button>
                     <div id="add_suggests" title="Add suggestion">
                         <div class="ui-widget">
@@ -256,7 +253,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Supports<br /><textarea id="supports" cols="40"></textarea></label>
+                    <label>Supports (mod has specific code to relating to these mods or is known to play well with them)<br /><textarea id="supports" cols="40"></textarea></label>
                     <button type="button" id="add_supports_button">Add</button>
                     <div id="add_supports" title="Add supported">
                         <div class="ui-widget">
@@ -269,7 +266,7 @@
                 </li>
 
                 <li>
-                    <label>Conflicts with<br /><textarea id="conflicts" cols="40"></textarea></label>
+                    <label>Conflicts with (mod will break or will break these mods)<br /><textarea id="conflicts" cols="40"></textarea></label>
                     <button type="button" id="add_conflicts_button">Add</button>
                     <div id="add_conflicts" title="Add conflicted">
                         <div class="ui-widget">
@@ -286,7 +283,7 @@
         <div id="advanced_fields">
             <ol>
                 <li>
-                    <label>Provides<br /><textarea id="provides" cols="40"></textarea></label>
+                    <label>Provides (can be installed instead of these mods without problems)<br /><textarea id="provides" cols="40"></textarea></label>
                     <button type="button" id="add_provides_button">Add</button>
                     <div id="add_provides" title="Add provided">
                         <div class="ui-widget">
@@ -296,6 +293,9 @@
                             <label>Provided ID<br /><input type="text" id="add_provides_id" size="40"></label>
                         </div>
                     </div>
+                </li>
+                <li>
+                    <label><input type="checkbox" id="add_ksp_version_strict" value="1" size="40" /> Install only on exact KSP-Version match</label> in case this mods is not compatible with small KSP patches/hotfixes
                 </li>
 
             </ol>
@@ -307,7 +307,7 @@
                     <label>$kref<br /><input type="text" id="kref" size="40" /></label>
                 </li>
                 <li>
-                    <label>Update JSON<br /><textarea id="update_json" size="40">{}</textarea></label>
+                    <label>Update JSON<br /><textarea id="update_json" cols="40">{}</textarea></label>
                 </li>
             </ol>
         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -115,28 +115,28 @@
         <div>
             <ol id="mandatory_fields">
                 <li>
-                    <label>Identifier<br /><input type="text" id="identifier" placeholder="Machine-friendly name for the mod" size="40" pattern="^[A-Za-z][A-Za-z0-9-]*$" /></label> <em id="identifier_info"></em>
+                    <label>Identifier - Machine-friendly name for the mod (only numbers, letters, and dashes, no spaces)<br /><input type="text" id="identifier" placeholder="AwesomeMod" size="40" pattern="^[A-Za-z][A-Za-z0-9-]*$" /></label> <em id="identifier_info"></em>
                 </li>
                 <li>
-                    <label>Name<br /><input type="text" id="name" placeholder="User-friendly name for the mod" size="40" /></label> <em id="name_info"></em>
+                    <label>Name - User-friendly name for the mod<br /><input type="text" id="name" placeholder="Awesome Mod" size="40" /></label> <em id="name_info"></em>
                 </li>
                 <li>
                     <label><input type="checkbox" id="add_vref" value="1" onchange="switch_add_vref()" /> Installs <code>.version</code> file</label>
                 </li>
                 <li>
-                    <label>Version<br /><input type="text" id="version" size="40" /></label>
+                    <label>Mod version<br /><input type="text" id="version" size="40" /></label>
                 </li>
                 <li>
-                    <label>Abstract<br /><textarea id="abstract" placeholder="A short description of what the mod does" size="40"></textarea></label>
+                    <label>Abstract - A short description of what the mod does<br /><textarea id="abstract" placeholder="Awesome mod makes everything better!" size="40"></textarea></label>
                 </li>
                 <li>
-                    <label>Download<br /><input type="url" id="download" size="40" /></label>
+                    <label>Download URL<br /><input type="url" id="download" size="40" /></label>
                 </li>
                 <li>
-                    <label>Authors (one per line)<br /><textarea id="author" cols="40"></textarea></label>
+                    <label>Mod author(s) (one per line)<br /><textarea id="author" cols="40"></textarea></label>
                 </li>
                 <li>
-                    <label>Licenses<br /><textarea id="license" cols="40"></textarea></label>
+                    <label>License(s)<br /><textarea id="license" cols="40"></textarea></label>
                     <button type="button" id="add_license_button">Add</button> Users can choose to which of these to adhere
                     <div id="add_license" title="Add license">
                         <a href="https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#license" target="_blank">About valid licenses</a>
@@ -145,29 +145,20 @@
                         </div>
                     </div>
                 </li>
-
-            </ol>
-        </div>
-        <h3>Extra Info (suggested)</h3>
-        <div id="extra_fields">
-            <ol>
                 <li>
                     <label>KSP-Version<br /><input type="text" id="ksp_version" size="40" /></label> examples: <code>==1.0</code> or <code>&lt;=1.1&gt;=1.0.3</code>
                 </li>
-                <li>
-                    <label><input type="checkbox" id="add_ksp_version_strict" value="1" size="40" /> Install only on exact KSP-Version match</label>
-                </li>
-            </ol>
 
+            </ol>
         </div>
-        <h3>Ressources (suggested)</h3>
+        <h3>Resources (suggested)</h3>
         <div id="resources_fields">
             <ol>
                 <li>
-                    <label>Repository<br /><input type="url" id="resources_repository" size="40" /></label> The repository where the module source can be found
+                    <label>Homepage<br /><input type="url" id="resources_homepage" size="40" /></label> The preferred landing page for the mod
                 </li>
                 <li>
-                    <label>Homepage<br /><input type="url" id="resources_homepage" size="40" /></label> The preferred landing page for the mod
+                    <label>Repository<br /><input type="url" id="resources_repository" size="40" /></label> The repository where the mod's source can be found
                 </li>
                 <li>
                     <label>Bugtracker<br /><input type="url" id="resources_bugtracker" size="40" /></label> The mod's bugtracker if it exists
@@ -176,24 +167,24 @@
                     <label>CI<br /><input type="url" id="resources_ci" size="40" /></label> Continuous Integration (e.g. Jenkins) Server where the module is being built
                 </li>
                 <li>
-                    <label>SpaceDock<br /><input type="url" id="resources_spacedock" size="40" /></label> The mod on SpaceDock
+                    <label>SpaceDock<br /><input type="url" id="resources_spacedock" size="40" /></label> The mod's SpaceDock page
                 </li>
                 <li>
-                    <label>Manual<br /><input type="url" id="resources_manual" size="40" /></label> The mod's bugtracker if it exists
+                    <label>Manual<br /><input type="url" id="resources_manual" size="40" /></label> The mod's user manual if it exists
                 </li>
                 <li>
-                    <label>License<br /><input type="url" id="resources_license" size="40" /></label> The mod's license
+                    <label>License<br /><input type="url" id="resources_license" size="40" /></label> A URL to the mod's license
                 </li>
                 <li>
-                    <label>Screenshot<br /><input type="url" id="resources_x_screenshot" size="40" /></label>
+                    <label>Screenshot<br /><input type="url" id="resources_x_screenshot" size="40" /></label> A direct URL to a screenshot of the mod
                 </li>
             </ol>
         </div>
-        <h3>Special Install</h3>
+        <h3>Install instructions</h3>
         <div id="install_fields">
-            <ol>
+            <ol> If this mod requires other mods to be installed alongside it, use Relationships.<b>Do not use install instructions to install multiple mods.</b>
                 <li>
-                    <label>Install Root<br /><input type="text" id="file" size="40" /></label>
+                    <label>Install from<br /><input type="text" id="file" size="40" /></label>
                 </li>
                 <li>
                     <label>
@@ -213,14 +204,14 @@
                 </li>
             </ol>
         </div>
-        <h3>References</h3>
+        <h3>Relationships</h3>
         <div id="references_fields">
             <p>
                 You can add version restrictions. For example <code>SomeModID</code> can be restricted like <code>SomeModID ==1.0</code> or <code>SomeModID &lt;=1.1 &gt;=1.0.3</code>
             </p>
             <ol>
                 <li>
-                    <label>Depends on<br /><textarea id="depends" cols="40"></textarea></label>
+                    <label>Depends on (mod will not run without it)<br /><textarea id="depends" cols="40"></textarea></label>
                     <button type="button" id="add_depends_button">Add</button>
                     <div id="add_depends" title="Add requirement">
                         <div class="ui-widget">
@@ -232,7 +223,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Recommends<br /><textarea id="recommends" cols="40"></textarea></label>
+                    <label>Recommends (mod is greatly complimented by these mods)<br /><textarea id="recommends" cols="40"></textarea></label>
                     <button type="button" id="add_recommends_button">Add</button>
                     <div id="add_recommends" title="Add recommendation">
                         <div class="ui-widget">
@@ -244,7 +235,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Suggests<br /><textarea id="suggests" cols="40"></textarea></label>
+                    <label>Suggests (mod is complimented by these mods)<br /><textarea id="suggests" cols="40"></textarea></label>
                     <button type="button" id="add_suggests_button">Add</button>
                     <div id="add_suggests" title="Add suggestion">
                         <div class="ui-widget">
@@ -256,7 +247,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Supports<br /><textarea id="supports" cols="40"></textarea></label>
+                    <label>Supports (mod has specific code to relating to these mods)<br /><textarea id="supports" cols="40"></textarea></label>
                     <button type="button" id="add_supports_button">Add</button>
                     <div id="add_supports" title="Add supported">
                         <div class="ui-widget">
@@ -269,7 +260,7 @@
                 </li>
 
                 <li>
-                    <label>Conflicts with<br /><textarea id="conflicts" cols="40"></textarea></label>
+                    <label>Conflicts with (mod will be break or be broken by these mods)<br /><textarea id="conflicts" cols="40"></textarea></label>
                     <button type="button" id="add_conflicts_button">Add</button>
                     <div id="add_conflicts" title="Add conflicted">
                         <div class="ui-widget">
@@ -286,7 +277,7 @@
         <div id="advanced_fields">
             <ol>
                 <li>
-                    <label>Provides<br /><textarea id="provides" cols="40"></textarea></label>
+                    <label>Provides - advanced field that lets mods be interchangeable<br /><textarea id="provides" cols="40"></textarea></label>
                     <button type="button" id="add_provides_button">Add</button>
                     <div id="add_provides" title="Add provided">
                         <div class="ui-widget">
@@ -297,7 +288,9 @@
                         </div>
                     </div>
                 </li>
-
+                <li>
+                    <label><input type="checkbox" id="add_ksp_version_strict" value="1" size="40" /> Install only on exact KSP-Version match - advanced field in cases where mods are not compatible with small KSP patches/hotfixes</label>
+                </li>
             </ol>
         </div>
         <h3>Don't Touch</h3>

--- a/static/index.html
+++ b/static/index.html
@@ -253,7 +253,7 @@
                     </div>
                 </li>
                 <li>
-                    <label>Supports (mod has specific code to relating to these mods or is known to play well with them)<br /><textarea id="supports" cols="40"></textarea></label>
+                    <label>Supports (mod has specific code to relating to these mods ex. Toolbar integration)<br /><textarea id="supports" cols="40"></textarea></label>
                     <button type="button" id="add_supports_button">Add</button>
                     <div id="add_supports" title="Add supported">
                         <div class="ui-widget">
@@ -266,7 +266,7 @@
                 </li>
 
                 <li>
-                    <label>Conflicts with (mod will be break or be broken by these mods)<br /><textarea id="conflicts" cols="40"></textarea></label>
+                    <label>Conflicts with (mod will break or be broken by these mods)<br /><textarea id="conflicts" cols="40"></textarea></label>
                     <button type="button" id="add_conflicts_button">Add</button>
                     <div id="add_conflicts" title="Add conflicted">
                         <div class="ui-widget">


### PR DESCRIPTION
A lousy title and commit message, this is just a bunch of cosmetic changes. Some things reworded to use CKAN nomenclature (like relationships). Many fields have increased explanation of what's expected. "KSP_version" moved up into "mandatory" (https://github.com/KSP-CKAN/CKAN/pull/1742 for more). Strict version matching moved into "advanced". And much more.

Closes #9
