### PR TITLE
Add release status

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -152,15 +152,6 @@
                     <br />
                     <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
-                <li>
-                    <label>
-                        Release Status <select id="release_status">
-                            <option selected="selected">stable</option>
-                            <option>testing</option>
-                            <option>development</option>
-                        </select>
-                    </label>
-                </li>
             </ol>
         </div>
         <h3>Resources (Suggested)</h3>
@@ -291,6 +282,15 @@
         <h3>Advanced</h3>
         <div id="advanced_fields">
             <ol>
+                <li>
+                    <label>
+                        Release Status <select id="release_status">
+                            <option selected="selected">stable</option>
+                            <option>testing</option>
+                            <option>development</option>
+                        </select>
+                    </label>
+                </li>
                 <li>
                     <label>Provides (can be installed instead of these mods without problems)<br /><textarea id="provides" cols="40"></textarea></label>
                     <button type="button" id="add_provides_button">Add</button>

--- a/static/index.html
+++ b/static/index.html
@@ -153,7 +153,8 @@
                     <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
                 <li>
-                    <label>Release Status <select name="release_status">
+                    <label>
+                        Release Status <select id="release_status">
                             <option selected="selected">stable</option>
                             <option>testing</option>
                             <option>development</option>

--- a/static/index.html
+++ b/static/index.html
@@ -134,6 +134,8 @@
                 </li>
                 <li>
                     <label>Mod Authors (one per line)<br /><textarea id="author" cols="40"></textarea></label>
+                    <br />
+                    <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
                 <li>
                     <label>License(s)<br /><textarea id="license" cols="40"></textarea></label>
@@ -150,7 +152,14 @@
                     <br />
                     <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
-
+                <li>
+                    <label>Release Status <select name="release_status">
+                            <option selected="selected">stable</option>
+                            <option>testing</option>
+                            <option>development</option>
+                        </select>
+                    </label>
+                </li>
             </ol>
         </div>
         <h3>Resources (Suggested)</h3>

--- a/static/script.js
+++ b/static/script.js
@@ -223,6 +223,7 @@ function generate_netkan() {
     if ($("#add_vref:checked").val()) {
         o["$vref"] = "#/ckan/ksp-avc";
     }
+    sets(o, "release_status");
 
     var resources = {};
     sets(resources, "resources_bugtracker", "bugtracker");


### PR DESCRIPTION
While providing this field is not mandatory, chosing a release status is. If the field is not provided (per spec) clients default to "stable".
