### PR TITLE
Enable schema validation for resulting ckan file

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -331,7 +331,7 @@
     </div>
     <br />
     <div>
-        <label>Output<br /><textarea id="json_output" cols="40"></textarea></label>
+        <label>Output<br /><textarea id="json_output" cols="40" readonly="readonly"></textarea></label>
     </div>
     <br />
     <small>

--- a/static/script.js
+++ b/static/script.js
@@ -286,16 +286,41 @@ function generate_netkan() {
         }
     }
 
-    var validation_result = tv4.validateMultiple(o, ckan_schema);
+    var dummies = {};
+    var autofill = modes_autofill[mode];
+    for (var i in mandatory_fields) {
+        var k = mandatory_fields[i];
+        if (autofill.includes(k)) {
+            dummies[k] = "any";
+        }
+    }
+    if (o["$vref"]) {
+        dummies["version"] = "any";
+    }
+    if (dummies.download) {
+        dummies.download = "http://example.com";
+    }
+    if (dummies.license) {
+        dummies.license = "restricted";
+    }
+    var dummy_filled = {};
+    for (var k in dummies) {
+        dummy_filled[k] = dummies[k];
+    }
+    for (var k in o) {
+        dummy_filled[k] = o[k];
+    }
+
+
+    var validation_result = tv4.validateMultiple(dummy_filled, ckan_schema);
     if (!validation_result.valid) {
         var e = validation_result.errors;
-        var msg = "Not valid as .ckan, but maybe valid as .netkan - who knows?\n\nErrors:";
+        var msg = "There were errors validating against CKAN-Schema with dummy values for fields normally filled by NetKAN:";
         for (var i = 0; i < e.length; i++) {
             msg = msg + "\n" + e[i].message;
         }
         alert(msg);
     }
-
     $("#json_output").val(JSON.stringify(o, null, "\t"));
 
 


### PR DESCRIPTION
Populate fields filled by NetKAN with dummy values for validation

Pro:
- at least some validation

Con:
- NetKAN fields are still not validated
