### PR TITLE
Replace proceed and generate buttons with live updating

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -5,13 +5,16 @@
     <meta charset="utf-8" />
     <title>Metadata Webtool</title>
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.4/themes/ui-lightness/jquery-ui.css" integrity="sha384-mf72GmkUsTKkmt05bABaLGVDDWha9SeDJTZ0tTQv4t1Tgz3CRQX+PENxJR8nQ7Tk" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/pepper-grinder/jquery-ui.css" integrity="sha384-fE+54ppMzps3SBhYPdVVjcCKsi8gtmBr9rRCwh9nLYOMQZ91PqRhTvEVdLU9lQUc" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-2.2.4.js" integrity="sha384-TlQc6091kl7Au04dPgLW7WK3iey+qO8dAi/LdwxaGBbszLxnizZ4xjPyNrEf+aQt" crossorigin="anonymous"></script>
-    <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.js" integrity="sha384-YwCdhNQ2IwiYajqT/nGCj0FiU5SR4oIkzYP3ffzNWtu39GKBddP0M0waDU7Zwco0" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js" integrity="sha384-JPbtLYL10d/Z1crlc6GGGGM3PavCzzoUJ1UxH0bXHOfguWHQ6XAWrIzW+MBGGXe5" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tv4/1.2.7/tv4.js" integrity="sha384-BLm4KsxYkSCYQ0dAKxVu8c8GMAwhg4FR+vovFz8X9uETUfb1bn3F96Ebm74NAcYc" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.0.0/jszip.js" integrity="sha384-JoB0oWpuxbS3K5bzPuKlceF17bqFYnvaq6rt3BOiTYox+9dmwWZ8jPJrxNXo7SL/" crossorigin="anonymous"></script>
     <script src="data.js"></script>
     <style>
+        html, body {
+            background-color: hsl(51, 20%, 70%);
+        }
         h1 {
             background-image: url(favicon.ico);
             background-position: left center;
@@ -35,9 +38,42 @@
             background-color: lightgreen;
         }
 
+        #edit_json {
+            width: 100%;
+            height: 15em;
+        }
+
+        #reset_button {
+            float: right;
+        }
+
+        #output_container > * {
+            display: inline-block;
+            vertical-align: top;
+            width: 50%;
+            box-sizing: border-box;
+            padding: 0.5em;
+        }
+
         #json_output {
             border-style: solid;
             border-width: thin;
+        }
+
+        #failure_box, #success_box {
+            margin: 1em 0;
+        }
+
+        #submit_to_index {
+            background: #2ea44f;
+            color: #fff;
+            margin: 1em auto;
+            display: block;
+            white-space: nowrap;
+        }
+
+        #validation_errors {
+            padding: 1em;
         }
     </style>
     <script src="script.js"></script>
@@ -58,11 +94,7 @@
                 <li>
                     <label>SpaceDock ID<br /><input type="number" id="spacedock_id" required="required" /></label>
                 </li>
-                <li>
-                    <button type="button" onclick="proceed_spacedock()">Proceed</button>
-                </li>
             </ol>
-
         </div>
         <div id="tab_github">
             <ol>
@@ -81,18 +113,12 @@
                         You can use this field to provide a regular expression to filter which file to use
                     </small>
                 </li>
-                <li>
-                    <button type="button" onclick="proceed_github()">Proceed</button>
-                </li>
             </ol>
         </div>
         <div id="tab_http">
             <ol>
                 <li>
                     <label>URI<br /><input type="url" id="http_url" required="required" size="40" /></label>
-                </li>
-                <li>
-                    <button type="button" onclick="proceed_http()">Proceed</button>
                 </li>
             </ol>
         </div>
@@ -102,9 +128,6 @@
                 <li>
                     <label>$kref<br /><input type="text" id="kref_kref" size="40" /></label>
                 </li>
-                <li>
-                    <button type="button" onclick="proceed_kref()">Proceed</button>
-                </li>
             </ol>
         </div>
         <div id="tab_edit">
@@ -113,50 +136,42 @@
                 <li>
                     <label>NetKAN File Contents<br /><textarea id="edit_json" cols="40"></textarea></label>
                 </li>
-                <li>
-                    <button type="button" onclick="proceed_edit()">Proceed</button>
-                </li>
             </ol>
         </div>
         <div id="tab_other">
-            <ol>
-                <li>
-                    <button type="button" onclick="proceed_other()">Proceed</button>
-                </li>
-            </ol>
+            <p>Fill in all fields on your own&mdash;good luck!</p>
         </div>
     </div>
     <p>
-        Fields filled by the NetKAN indexer look like <input type="text" class="filled-by-netkan" disabled="disabled" /> - you can override auto-detection by setting a value yourself. <strong>If unsure - don't override.</strong>
+        <button type="button" id="reset_button">Reset</button>
+        <input type="text" class="filled-by-netkan" disabled="disabled" /> - Retrieved from host if empty
     </p>
     <div id="accordion">
-        <h3>Mandatory</h3>
+        <h3>Required</h3>
         <div>
             <ol id="mandatory_fields">
-                <li>
+                <li id="identifier_container">
                     <label>Identifier - Machine-friendly name for the mod (only numbers, letters, and dashes, no spaces)<br /><input type="text" id="identifier" placeholder="AwesomeMod" size="40" pattern="^[A-Za-z][A-Za-z0-9-]*$" /></label> <strong id="identifier_info"></strong>
                 </li>
-                <li>
+                <li id="name_container">
                     <label>Name - User-friendly name for the mod<br /><input type="text" id="name" placeholder="Awesome Mod" size="40" /></label> <strong id="name_info"></strong>
                 </li>
                 <li>
                     <label><input type="checkbox" id="add_vref" value="1" onchange="switch_add_vref()" /> Installs <code>.version</code> file</label>
                 </li>
-                <li>
+                <li id="version_container">
                     <label>Mod Version<br /><input type="text" id="version" size="40" /></label>
                 </li>
-                <li>
+                <li id="abstract_container">
                     <label>Abstract - A short description of what the mod does<br /><textarea id="abstract" placeholder="Awesome mod makes everything better!" cols="40"></textarea></label>
                 </li>
-                <li>
+                <li id="download_container">
                     <label>Download URI<br /><input type="url" id="download" size="40" /></label>
                 </li>
-                <li>
+                <li id="author_container">
                     <label>Mod Authors (one per line)<br /><textarea id="author" cols="40"></textarea></label>
-                    <br />
-                    <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
-                <li>
+                <li id="license_container">
                     <label>License(s)<br /><textarea id="license" cols="40"></textarea></label>
                     <button type="button" id="add_license_button">Add</button> Users can choose to which of these to adhere
                     <div id="add_license" title="Add license">
@@ -169,14 +184,19 @@
                         </div>
                     </div>
                 </li>
-                <li>
-                    <label>KSP-Version<br /><input type="text" id="ksp_version" size="40" /></label> examples: <code>==1.0</code> or <code>&lt;=1.1&gt;=1.0.3</code> - set to <code>any</code> (or leave empty) to state compatibility with <em>all</em> versions
+                <li id="ksp_version_container">
+                    <label>Game version<br /><input type="text" id="ksp_version" size="40" /></label> examples: <code>==1.0</code> or <code>&lt;=1.1&gt;=1.0.3</code> - set to <code>any</code> (or leave empty) to state compatibility with <em>all</em> versions
                     <br />
                     <small>While not technically mandatory, not providing this field is considered bad practice.</small>
                 </li>
             </ol>
         </div>
-        <h3>Resources (Suggested)</h3>
+        <h3 id="optional_fields_header">Optional overrides (retrieved from host)</h3>
+        <div id="optional_fields_container">
+            <ol id="optional_fields">
+            </ol>
+        </div>
+        <h3>Resources (suggested)</h3>
         <div id="resources_fields">
             <ol>
                 <li>
@@ -357,21 +377,32 @@
         </div>
     </div>
     <br />
-    <div>
-        <button id="generate_netkan" type="button">Generate netkan</button>
+    <div id="output_container" class="ui-widget ui-state-default">
+        <div>
+            <label>JSON output:</label>
+            <pre id="json_output"></pre>
+        </div><div>
+            <label>Status:</label>
+            <div id="failure_box" class="ui-widget ui-state-error ui-corner-all toshow" style="display: none;">
+                <span class="ui-icon ui-icon-alert"></span>
+                <label>Metadata incomplete</label>
+                <pre id="validation_errors"></pre>
+            </div>
+            <div id="success_box" class="ui-widget ui-state-highlight ui-corner-all toshow" style="display: none;">
+                <span class="ui-icon ui-icon-check"></span>
+                <label>Metadata complete!</label>
+                <form action="https://github.com/KSP-CKAN/NetKAN/issues/new" method="get" target="_blank">
+                    <input type="hidden" name="body"  id="issue_body" />
+                    <input type="hidden" name="title" id="issue_title" />
+                    <br />
+                    <button id="submit_to_index" type="submit">Submit to Index</button>
+                </form>
+            </div>
+        </div>
+        <br />
+        <small>
+            Copyright (c) 2016&ndash;2021, see <a href="https://github.com/KSP-CKAN/metadata-webtool/blob/master/LICENSE.md">LICENSE</a>
+        </small>
     </div>
-    <br />
-    <div>
-        <label>Raw Output<br /><pre id="json_output"></pre></label>
-        <form action="https://github.com/KSP-CKAN/NetKAN/issues/new" method="get">
-            <input type="hidden" name="body" id="issue_body" />
-            <br />
-            <button type="submit">Submit to Index</button>
-        </form>
-    </div>
-    <br />
-    <small>
-        Copyright (c) 2016-2021, See <a href="https://github.com/KSP-CKAN/metadata-webtool/blob/master/LICENSE.md">LICENSE</a>
-    </small>
 </body>
 </html>


### PR DESCRIPTION
## Motivation

The webtool has a lot of potential, but it's currently a bit awkward to use and somewhat confusing.

https://ksp-ckan.github.io/metadata-webtool/

- The user has to click "Proceed" and "Generate netkan" buttons at the right time to make it work right
- Lots of fields that arguably should _not_ be included in a final netkan are included in a section labelled "Mandatory", with only a background color to suggest they may not actually be mandatory
- The "Submit to Index" button is barely noticeable and not clearly the end goal of the flow
  - Clicking it jumps to GitHub in the same tab, so you lose whatever you were working on in the tool, and the issue has no default title

## Changes

- Updated `jquery-ui` version from 1.11.4 to 1.12.1 so we can switch to the `pepper-grinder` theme which has some reddish tones like the CKAN logo, and the big yellow-orange bar at the top is gone
- Clicking one of the mode tabs now sets focus to the editable fields for that tab and updates the JSON output
- The box for pasting old metadata under "Edit existing" is bigger
- A new Reset button between the tabs and the accordion clears all the fields when clicked
- The Mandatory section is renamed Required
- Values that are auto-populated by the inflator no longer appear in the Mandatory/Required section; instead they are moved to a new "Optional overrides" section so they are out of the way and not confusing the user. This section is hidden when empty, which happens for modes that have no auto-populated fields. This way the user is only initially prompted to enter values that are truly needed (SpaceDock ID and identifier), but can still access all the fields if they wish.
- Now the Proceed and Generate netkan buttons are all removed
  - In their place, we automatically refresh the JSON metadata output every time the user makes any edit
  - The validation alert is replaced with a permanent output pane in the lower right, also updated every time the user makes any edit, which also reports problems with the fields in the tabs
    - When the metadata is valid, the output pane shows the button to submit an issue on GitHub, which now is green, opens in a new tab, and includes an autogenerated title
- Several buttons and selection controls are now skinned with `jquery-ui`

This should produce an overall more intuitive and pleasant user experience, since there should always be a clear next step (fill in or fix a named field, click submit when done).

### Considered and not done

For most of the time I was working on this, I had the output pane as `position: fixed; left: 0; right: 0; bottom: 0;`, whch had the advantage of making it always visible so the user would not have to scroll down to see the errors or the success message. However, it would also cover up some of the editing fields, and I could not figure out a way to avoid that. So I put it back to regular flow layout. Maybe we can figure this out in the future.