### PR TITLE
Allow YAML format for .netkans

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,7 @@
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js" integrity="sha384-JPbtLYL10d/Z1crlc6GGGGM3PavCzzoUJ1UxH0bXHOfguWHQ6XAWrIzW+MBGGXe5" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tv4/1.2.7/tv4.js" integrity="sha384-BLm4KsxYkSCYQ0dAKxVu8c8GMAwhg4FR+vovFz8X9uETUfb1bn3F96Ebm74NAcYc" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.0.0/jszip.js" integrity="sha384-JoB0oWpuxbS3K5bzPuKlceF17bqFYnvaq6rt3BOiTYox+9dmwWZ8jPJrxNXo7SL/" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js" integrity="sha384-+pxiN6T7yvpryuJmE1gM9PX7yQit15auDb+ZwwvJOd/4be2Cie5/IuVXgQb/S9du" crossorigin="anonymous"></script>
     <script src="data.js"></script>
     <style>
         html, body {
@@ -58,6 +59,7 @@
         #json_output {
             border-style: solid;
             border-width: thin;
+            padding: 0.5em;
         }
 
         #failure_box, #success_box {
@@ -191,7 +193,7 @@
                 </li>
             </ol>
         </div>
-        <h3 id="optional_fields_header">Optional overrides (retrieved from host)</h3>
+        <h3 id="optional_fields_header">Optional overrides (retrieved from host, leave blank unless you know what you're doing)</h3>
         <div id="optional_fields_container">
             <ol id="optional_fields">
             </ol>
@@ -379,7 +381,7 @@
     <br />
     <div id="output_container" class="ui-widget ui-state-default">
         <div>
-            <label>JSON output:</label>
+            <label>YAML output:</label>
             <pre id="json_output"></pre>
         </div><div>
             <label>Status:</label>

--- a/static/script.js
+++ b/static/script.js
@@ -53,7 +53,7 @@ function update_mode(new_mode) {
 }
 
 function host_error(err) {
-    $("#json_output").text('{\n}');
+    $("#json_output").text('');
     $("#validation_errors").text(err);
     $("#failure_box").show();
     $("#success_box").hide();
@@ -133,15 +133,15 @@ function proceed_kref() {
 
 function proceed_edit() {
     $("#edit_json").focus();
-    var o = JSON.parse(get_val("edit_json"));
+    var o = jsyaml.load(get_val("edit_json"));
     var ref_fields = ["depends", "recommends", "suggests", "supports", "conflicts"];
     var not_mapped = ["resources", "install",
         "depends", "recommends", "suggests", "supports", "conflicts", "provides",
         "ksp_version_strict", "ksp_version", "ksp_version_min", "ksp_version_max",
-        "$vref"
+        "$vref", "$kref"
     ];
     for (var key in o) {
-        if (!not_mapped.includes("key")) {
+        if (!not_mapped.includes(key)) {
             $("#" + key).val(o[key]);
         }
     }
@@ -375,7 +375,7 @@ function generate_netkan() {
     var uj = get_val("update_json");
     var ujo;
     try {
-        ujo = JSON.parse(uj);
+        ujo = jsyaml.load(uj);
     } catch (err) {
         alert("Update JSON field not applied\n\n" + err);
     }
@@ -443,7 +443,7 @@ function generate_netkan() {
         $("#success_box").show();
     }
 
-    var data = JSON.stringify(o, null, "    ");
+    var data = jsyaml.dump(o);
     $("#issue_title").val(`Add ${get_val("identifier")}`);
     $("#issue_body").val("\n\n```json\n" + data + "\n```\n");
     $("#json_output").text(data);


### PR DESCRIPTION
## Motivation

See KSP-CKAN/CKAN#3367, we might want to allow .netkans to use YAML format. If so, the metadata-webtool should take advantage of it by generating YAML.

## Changes

- The JS-YAML library is loaded (its functions go into `jsyaml`)
- `JSON.stringify` is replaced with `jsyaml.dump`
- `JSON.parse` is replaced with `jsyaml.load`

This will make the webtool generate YAML if merged.