### PR TITLE
Refresh metadata every night

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,23 @@
 name: Deploy Metadata Webtool
 on:
-    push:
-        branches:
-            - master
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '53 22 * * *'
+
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2.3.4
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
 
-            - name: Refresh Data
-              run: python refresh_datajs.py
+      - name: Refresh Data
+        run: python refresh_datajs.py
 
-            - name: Deploy
-              uses: JamesIves/github-pages-deploy-action@4.1.1
-              with:
-                  folder: static
-                  branch: gh-pages
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          folder: static
+          branch: gh-pages


### PR DESCRIPTION
## Motivation

The metadata webtool embeds a list of all mods' names and identifiers, which is pulled in its deploy workflow. This means the list of mods in the dependency popups is only as up to date as the last time that workflow was run, which up till now has been the last time we made code changes. So if we go a long time without changing the metadata-webtool, the mods and their names would gradually get more and more outdated.

## Changes

Now the deploy workflow is scheduled to run 67 minutes before midnight UTC (one hour before the workflow from KSP-CKAN/CKAN-ModInstaller#1 in case there's any congestion with our jobs). This will prevent the metadata from getting too stale.
