### PR TITLE
Discourage populating release_status

### DIFF
--- a/refresh_datajs.py
+++ b/refresh_datajs.py
@@ -126,7 +126,8 @@ modes_autofill = {
         "resources.repository",
         "resources.bugtracker",
         "version",
-        "license"
+        "license",
+        "release_status"
     ],
     "http": [
         "download",
@@ -148,7 +149,8 @@ modes_autofill = {
         "resources.repository",
         "resources.spacedock",
         "resources.x_screenshot",
-        "version"
+        "version",
+        "release_status"
     ]
 }
 


### PR DESCRIPTION
Netkans shouldn't set `release_status`, but it's common for webtool-generated ones to have it.

Now this field is added to `mods_autofill` so it will be highlighted green indicating that it will be filled in automatically.
